### PR TITLE
feat!: render Fragment instead div wrapper

### DIFF
--- a/lib/blocksRenderer.ts
+++ b/lib/blocksRenderer.ts
@@ -1,4 +1,4 @@
-import { h } from 'vue';
+import { h, Fragment, Comment } from 'vue';
 
 import { Block } from './block';
 
@@ -80,13 +80,15 @@ export const BlocksRenderer = (props: BlocksRendererProps) => {
     Block({ content, componentsContext }),
   );
 
+  if(componentsContext.missingBlockTypes.length)
+    divs.unshift(h(Comment, `missingBlockTypes: ${componentsContext.missingBlockTypes}`))
+
+  if(componentsContext.missingModifierTypes.length)
+    divs.unshift(h(Comment, `missingModifierTypes: ${componentsContext.missingModifierTypes}`))
+
   return h(
-    'div',
-    {
-      class: 'strapi-blocks-wrapper',
-      missingBlockTypes: componentsContext.missingBlockTypes,
-      missingModifierTypes: componentsContext.missingModifierTypes,
-    },
-    divs,
+    Fragment,
+    divs
   );
+
 };

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -90,9 +90,14 @@ const blocks2 = mount(StrapiBlocks, {
 });
 
 describe('render blocks', () => {
-  it('non existing block types and modifiers', () => {
+  it('non existing block modifiers', () => {
     expect(blocks2.html()).toContain(
-      '<div class="strapi-blocks-wrapper" missingblocktypes="nonExistingType1,text2,nonExistingType2" missingmodifiertypes="nonExistingModifier1,nonExistingModifier2">',
+      'missingModifierTypes: nonExistingModifier1,nonExistingModifier2"',
+    );
+  });
+  it('non existing block types', () => {
+    expect(blocks2.html()).toContain(
+      'missingBlockTypes: nonExistingType1,text2,nonExistingType2"',
     );
   });
 });


### PR DESCRIPTION
- improves semantics for SEO
- improves styles for tailwindcss typography

hi @niklasfjeldberg pls check, also talk about the major 


Migration Guide (is needed):

```diff
-<StrapiBlocks :content="content" />
+<div class="strapi-blocks-wrapper">
+  <StrapiBlocks :content="content" />
+</div>
```